### PR TITLE
Adding --network flag to `wp core update-db`

### DIFF
--- a/auto-update.sh
+++ b/auto-update.sh
@@ -35,7 +35,7 @@ if [ ! -z $checkupd ]; then
 
 	logger "[WPAutoUpdate] Core update: ${coreupdate} to ${updateto}"
 
-	dbupdate=`wp $flags core update-db --no-color | grep "^Success:" | tr -d '\n'`
+	dbupdate=`wp $flags core update-db --no-color --network | grep "^Success:" | tr -d '\n'`
 	dbupdate=${dbupdate/Success: /}
 	logger "[WPAutoUpdate] DB update: ${dbupdate}"
 


### PR DESCRIPTION
Makes sure the database update gets applied to all sites on a multisite.  Looked through this and I believe this is the only place that needs the network flag.
